### PR TITLE
Adapt to Jest 28

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   process(src) {
-    return (
-      "module.exports = require('pug').compile(" + JSON.stringify(src) + ");"
-    );
+    return {
+      code: "module.exports = require('pug').compile(" + JSON.stringify(src) + ");",
+    };
   }
 };


### PR DESCRIPTION
This PR adapts jest-transform-pug to the newest version of Jest. Since version 28 `process` method cannot return string anymore: https://jestjs.io/docs/28.x/upgrading-to-jest28#transformer.