### PR TITLE
Pass in filename option to pug

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = {
-  process(src) {
+  process(src, filename) {
     return {
-      code: "module.exports = require('pug').compile(" + JSON.stringify(src) + ");",
+      code: "module.exports = require('pug').compile(" + JSON.stringify(src) + ", { filename: " + JSON.stringify(filename) + " });",
     };
   }
 };


### PR DESCRIPTION
This PR passes in the `filename` option to `pug.compile()` so that pug knows where to look based on relative paths.

Fixes #48 